### PR TITLE
feat: 독서록 entity 설계(#19)

### DIFF
--- a/apps/book-log/src/book-log/book-log.controller.ts
+++ b/apps/book-log/src/book-log/book-log.controller.ts
@@ -20,6 +20,11 @@ export class BookLogController {
     return {books: books}
   }
   // 독서록 작성
+  // 도서 정보 저장(1)
+  @Post('')
+  async bookInfoSave() {
+    
+  }
   
   // 특정 독서록 상세 조회 ?
 

--- a/apps/book-log/src/book-log/book-log.service.ts
+++ b/apps/book-log/src/book-log/book-log.service.ts
@@ -23,8 +23,6 @@ export class BookLogService {
       'X-Naver-Client-Id': process.env.NAVER_CLIENT_ID,
       'X-Naver-Client-Secret': process.env.NAVER_SECRET,
     };
-    console.log(process.env.NAVER_CLIENT_ID)
-    console.log(process.env.NAVER_SECRET)
     try {
       const response = await lastValueFrom(
         this.httpService.get(url, { headers }),

--- a/apps/book-log/src/book-log/entity/book-log.entity.ts
+++ b/apps/book-log/src/book-log/entity/book-log.entity.ts
@@ -1,0 +1,41 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from "typeorm";
+import { BaseTable } from "../../common/entity/base-table.entity";
+
+@Entity()
+export class BookLog extends BaseTable {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @Column()
+  logTitle: string;
+
+  @Column({type: "text"})
+  text: string;
+
+  @Column({length: 255})
+  review: string;
+
+  @Index()
+  @Column()
+  category: string;
+
+  @Column()
+  bookTitle: string;
+
+  @Column()
+  bookImage: string;
+
+  @Column({length: 50})
+  author: string;
+
+  @Column({length: 50})
+  publisher: string;
+
+  @Index() // 공개 범위 필터링 최적화
+  @Column({ type: "enum", enum: ["public", "private", "followers"], default: "public" })
+  visibility: "public" | "private" | "followers";
+}

--- a/apps/book-log/src/common/entity/base-table.entity.ts
+++ b/apps/book-log/src/common/entity/base-table.entity.ts
@@ -1,0 +1,16 @@
+import { CreateDateColumn, UpdateDateColumn, VersionColumn } from "typeorm";
+import { Exclude } from "class-transformer"
+
+export class BaseTable{
+  @CreateDateColumn()
+  @Exclude()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  @Exclude()
+  updatedAt: Date;
+
+  @VersionColumn()
+  @Exclude()
+  version: number;
+}


### PR DESCRIPTION
## 관련 이슈
#19 

## 작업 내용
- 독서록 엔티티 설계
- 기존 도서 정보 테이블과 독서록 테이블의 분리에서 하나로 합침

## 상세
- 도서 정보 독서록 테이블에 책 정보 삽입